### PR TITLE
Added option to ignore invalid certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Or build and install it yourself as:
       --server SERVER                  SMTP Server, default is localhost.
       --port PORT                      SMTP Port, default is 25.
       --ssl                            Use SSL, default is false.
+  --ignorecert                     Ignore the SMTP server certificate when using --ssl.
       --username USER                  SMTP user.
       --password PASSWORD              SMTP password.
       --cc address                     Add a cc address.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Or build and install it yourself as:
       --server SERVER                  SMTP Server, default is localhost.
       --port PORT                      SMTP Port, default is 25.
       --ssl                            Use SSL, default is false.
-  --ignorecert                     Ignore the SMTP server certificate when using --ssl.
+      --ignorecert                     Ignore the SMTP server certificate when using --ssl.
       --username USER                  SMTP user.
       --password PASSWORD              SMTP password.
       --cc address                     Add a cc address.

--- a/bin/smitty
+++ b/bin/smitty
@@ -16,7 +16,7 @@ rescue Docopt::Exit => e
 end
 
 # Create SMTP connection and set Mail default
-smtp_conn = Smitty.smtp_connect(args['--server'], args['--port'], args['--ssl'], args['--username'], args['--password'])
+smtp_conn = Smitty.smtp_connect(args['--server'], args['--port'], args['--ssl'], args['--username'], args['--password'], args['--ignorecert'])
 Mail.defaults do
   delivery_method :smtp_connection, { :connection => smtp_conn }
 end

--- a/lib/smitty/smtp_connect.rb
+++ b/lib/smitty/smtp_connect.rb
@@ -1,12 +1,20 @@
 require 'net/smtp'
 
 module Smitty
-  def self.smtp_connect(server, port, ssl, username, password)
+  def self.smtp_connect(server, port, ssl, username, password, ignorecert)
     begin
       smtp_server = server.nil? ? 'localhost' : server
       smtp_port = port.nil? ? 25 : port.to_i
       smtp_conn = Net::SMTP.new(smtp_server, smtp_port)
-      smtp_conn.enable_starttls() if ssl
+      if ssl
+        if ignorecert
+          context = Net::SMTP.default_ssl_context
+          context.verify_mode = OpenSSL::SSL::VERIFY_NONE
+          smtp_conn.enable_starttls(context)
+        else
+          smtp_conn.enable_starttls()
+        end
+      end
       if username
         Smitty.croak('No password provided') if password.nil?
         if ssl

--- a/lib/smitty/usage.rb
+++ b/lib/smitty/usage.rb
@@ -25,6 +25,7 @@ Options:
   --server SERVER                  SMTP Server, default is localhost.
   --port PORT                      SMTP Port, default is 25.
   --ssl                            Use SSL, default is false.
+  --ignorecert                     Ignore the SMTP server certificate when using --ssl.
   --username USER                  SMTP user.
   --password PASSWORD              SMTP password.
   --cc address                     Add a cc address.


### PR DESCRIPTION
It was a weird use case where I needed this, but wanted to request to merge this back into the main repo.